### PR TITLE
Update scikit-learn requirement to 1.1.X

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 mlflow[pipelines]>=1.27.0
 pandas>=1.3.*
 pandas-profiling>=3.1.*
-scikit-learn>=1.0.*
+scikit-learn>=1.1.*
 ipykernel>=6.12.*
 ipython>=7.32.*
 shap>=0.40.*


### PR DESCRIPTION
Signed-off-by: Mingyu Li <mingyu.li@databricks.com>

The example uses FunctionTransformer with parameter feature_names_out
<img width="767" alt="Screen Shot 2022-09-29 at 4 28 55 PM" src="https://user-images.githubusercontent.com/12734110/193159643-178102b4-7e43-4957-9b71-d6a01b14e96a.png">

The parameter was added in sklearn version 1.1
<img width="771" alt="Screen Shot 2022-09-29 at 4 28 30 PM" src="https://user-images.githubusercontent.com/12734110/193159685-8c30157c-3938-4fe6-9ef3-f9784365fa7b.png">

We have to update the version otherwise there will be test failure
<img width="1513" alt="Screen Shot 2022-09-29 at 4 30 46 PM" src="https://user-images.githubusercontent.com/12734110/193159761-e4e547b1-0e7b-4641-bc6d-917bbd1462d7.png">


I was able to install the requirements and run "mlp run" locally after the change.
<img width="1309" alt="Screen Shot 2022-09-29 at 4 25 12 PM" src="https://user-images.githubusercontent.com/12734110/193159803-fad16e76-20eb-4394-be7e-8b842ea9d982.png">
