### PR TITLE
remove default index column

### DIFF
--- a/steps/ingest.py
+++ b/steps/ingest.py
@@ -30,11 +30,10 @@ def load_file_as_dataframe(file_path: str, file_format: str) -> DataFrame:
         import pandas
 
         _logger.warning(
-            "Loading dataset CSV using `pandas.read_csv()` with default arguments and assumed index"
-            " column 0 which may not produce the desired schema. If the schema is not correct, you"
-            " can adjust it by modifying the `load_file_as_dataframe()` function in"
-            " `steps/ingest.py`"
+            "Loading dataset CSV using `pandas.read_csv()` with default arguments which may not"
+            " produce the desired schema. If the schema is not correct, you can adjust it"
+            " by modifying the `load_file_as_dataframe()` function in `steps/ingest.py`"
         )
-        return pandas.read_csv(file_path, index_col=0)
+        return pandas.read_csv(file_path)
     else:
         raise NotImplementedError


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

We do not want to set index when reading from csv. This is produces a dataframe unlike other data sources (parquet, spark sql, etc), and creates issues in `split`.