### PR TITLE
Add estimator params dict

### DIFF
--- a/steps/train.py
+++ b/steps/train.py
@@ -4,9 +4,10 @@ This module defines the following routines used by the 'train' step of the regre
 - ``estimator_fn``: Defines the customizable estimator type and parameters that are used
   during training to produce a model pipeline.
 """
+from typing import Dict, Any
 
 
-def estimator_fn():
+def estimator_fn(estimator_params: Dict[str, Any] = {}):
     """
     Returns an *unfitted* estimator that defines ``fit()`` and ``predict()`` methods.
     The estimator's input and output signatures should be compatible with scikit-learn
@@ -14,4 +15,4 @@ def estimator_fn():
     """
     from sklearn.linear_model import SGDRegressor
 
-    return SGDRegressor(random_state=42)
+    return SGDRegressor(random_state=42, **estimator_params)


### PR DESCRIPTION
While the example will currently work without this change, we want to maintain parity with https://github.com/mlflow/mlp-regression-template/blob/main/steps/train.py.
