### PR TITLE
Fix `custom_metrics.py`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mlflow[pipelines]>=1.27.0
+mlflow>=2.0
 pandas>=1.3.*
 pandas-profiling>=3.1.*
 scikit-learn>=1.0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-mlflow>=2.0
-pandas>=1.3.*
-pandas-profiling>=3.1.*
-scikit-learn>=1.0.*
-ipykernel>=6.12.*
-ipython>=7.32.*
-shap>=0.40.*
-jinja2==3.0.3
+mlflow>=2.0.0rc0
+ipykernel>=6.12
+ipython>=7.32

--- a/steps/custom_metrics.py
+++ b/steps/custom_metrics.py
@@ -36,14 +36,10 @@ def weighted_mean_squared_error(
                             metrics and the values are the scalar values of the metrics. For more
                             information, see
                             https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate.
-    :return: A single-entry dictionary containing the MSE metric. The key is the metric name and
-             the value is the scalar metric value. Note that custom metric functions can return
-             dictionaries with multiple metric entries as well.
+    :return: The WMSE metric value.
     """
-    return {
-        "weighted_mean_squared_error": mean_squared_error(
-            eval_df["prediction"],
-            eval_df["target"],
-            sample_weight=1 / eval_df["prediction"].values,
-        )
-    }
+    return mean_squared_error(
+        eval_df["prediction"],
+        eval_df["target"],
+        sample_weight=1 / eval_df["prediction"].values,
+    )

--- a/steps/custom_metrics.py
+++ b/steps/custom_metrics.py
@@ -21,8 +21,8 @@ from sklearn.metrics import mean_squared_error
 
 def weighted_mean_squared_error(
     eval_df: DataFrame,
-    builtin_metrics: Dict[str, int],  # pylint: disable=unused-argument
-) -> Dict[str, int]:
+    builtin_metrics: Dict[str, float],  # pylint: disable=unused-argument
+) -> float:
     """
     Computes the weighted mean squared error (MSE) metric.
 


### PR DESCRIPTION
- Depends on https://github.com/mlflow/mlflow/pull/7142.
- Update `weighted_mean_squared_error` to return a numeric scalar value.